### PR TITLE
Fix newly added clippy warnings

### DIFF
--- a/lcov2cobertura/src/lib.rs
+++ b/lcov2cobertura/src/lib.rs
@@ -348,7 +348,7 @@ pub fn parse_lines<P: AsRef<Path>, B: BufRead>(
                 cov_data
                     .packages
                     .entry(package_name.clone())
-                    .or_insert_with(Package::default)
+                    .or_default()
                     .insert_class(&relative_file_name);
             }
             Some("DA") => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -65,7 +65,7 @@ fn main() -> anyhow::Result<()> {
             args.base_dir.as_path(),
             &excludes,
         )?
-    } else if args.files.get(0) == Some(&PathBuf::from("-")) {
+    } else if args.files.first() == Some(&PathBuf::from("-")) {
         let mut input = Vec::new();
         let stdin = std::io::stdin();
         let mut handle = stdin.lock();
@@ -74,7 +74,7 @@ fn main() -> anyhow::Result<()> {
     } else {
         let filename = args
             .files
-            .get(0)
+            .first()
             .ok_or_else(|| anyhow::anyhow!("no filename given"))?
             .to_path_buf();
         lcov2xml::parse_file(filename.as_path(), args.base_dir.as_path(), &excludes)?


### PR DESCRIPTION
```
warning: use of `or_insert_with` to construct default value
   --> lcov2cobertura/src/lib.rs:351:22
    |
351 |                     .or_insert_with(Package::default)
    |                      ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ help: try: `or_default()`
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#unwrap_or_default
    = note: `#[warn(clippy::unwrap_or_default)]` on by default

warning: accessing first element with `args.files.get(0)`
  --> src/main.rs:68:15
   |
68 |     } else if args.files.get(0) == Some(&PathBuf::from("-")) {
   |               ^^^^^^^^^^^^^^^^^ help: try: `args.files.first()`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
   = note: `#[warn(clippy::get_first)]` on by default

warning: accessing first element with `args
                     .files.get(0)`
  --> src/main.rs:75:24
   |
75 |           let filename = args
   |  ________________________^
76 | |             .files
77 | |             .get(0)
   | |___________________^
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#get_first
help: try
   |
75 ~         let filename = args
76 +             .files.first()
   |
```